### PR TITLE
chore: add .claude/settings.json for per-repo plugin scoping

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": [
+    "velocity-workflow"
+  ],
+  "env": {}
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with domain-scoped `enabledPlugins`
- Domain: **INFRA** — loads only relevant plugins
- Closes #1

## Changes
```json
{
  "enabledPlugins": [
    "velocity-workflow"
  ],
  "env": {}
}
```

## Impact
- Reduces context budget consumption by 70-95%
- Only domain-relevant plugins load when working in this repo
- Reference: claude-plugins#20

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>