### PR TITLE
chore: deploy INFRA settings.json v2 (corrected format)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,138 @@
 {
-  "enabledPlugins": [
-    "velocity-workflow"
-  ],
-  "env": {}
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "version": "1.0.0",
+    "description": "Infrastructure domain profile - CORE only (22 plugins), minimal permissions",
+    "model": "claude-opus-4-6-20250116",
+    "thinking": { "enabled": true },
+    "autoCheckpoint": true,
+    "permissionMode": "plan",
+    "env": {
+        "ENABLE_TOOL_SEARCH": "auto:5",
+        "MAX_MCP_OUTPUT_TOKENS": "50000",
+        "MAX_THINKING_TOKENS": "31999"
+    },
+    "sandbox": { "enabled": true, "autoAllowBashIfSandboxed": true },
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/dev/claude/infra/claude-governance/hooks/branch-protection.sh",
+                        "timeout": 10,
+                        "statusMessage": "Running branch protection check..."
+                    }
+                ]
+            }
+        ],
+        "Stop": [
+            {
+                "matcher": "",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/dev/claude/infra/claude-governance/hooks/test-gate.sh",
+                        "statusMessage": "Running test gate..."
+                    }
+                ]
+            }
+        ]
+    },
+    "enabledPlugins": {
+        "velocity-workflow@velocity-tools": true,
+        "commit-commands@claude-plugins-official": true,
+        "code-review@claude-plugins-official": true,
+        "ralph-loop@claude-plugins-official": true,
+        "hookify@claude-plugins-official": true,
+        "claude-mem@claude-mem": true,
+        "claude-md-management@claude-plugins-official": true,
+        "claude-code-setup@claude-plugins-official": true,
+        "agent-sdk-dev@claude-plugins-official": true,
+        "plugin-dev@claude-plugins-official": true,
+        "pr-review-toolkit@claude-plugins-official": true,
+        "feature-dev@claude-plugins-official": true,
+        "playground@claude-plugins-official": true,
+        "pyright-lsp@claude-plugins-official": true,
+        "typescript-lsp@claude-plugins-official": true,
+        "coding-tutor@claude-plugins-official": true,
+        "context7@anthropic-agent-skills": true,
+        "context7-enhanced@anthropic-agent-skills": true,
+        "devops-automation@claude-plugins-official": true,
+        "velocity-workflow@hordago-plugins": true,
+        "compound-engineering@compound-engineering": true,
+        "planning-with-files@planning-with-files": true
+    },
+    "permissions": {
+        "allow": [
+            "Bash(git:*)",
+            "Bash(gh:*)",
+            "Bash(ls:*)",
+            "Bash(tree:*)",
+            "Bash(wc:*)",
+            "Bash(diff:*)",
+            "Bash(sort:*)",
+            "Bash(uniq:*)",
+            "Bash(cat:*)",
+            "Bash(head:*)",
+            "Bash(tail:*)",
+            "Bash(date:*)",
+            "Bash(env:*)",
+            "Bash(which:*)",
+            "Bash(pwd:*)",
+            "Bash(find:*)",
+            "Bash(jq:*)",
+            "Bash(yq:*)",
+            "Read(*)",
+            "Write(*.md)",
+            "Write(*.yml)",
+            "Write(*.yaml)",
+            "Write(*.json)",
+            "Write(*.toml)",
+            "Write(.github/**)",
+            "Write(.gitignore)",
+            "Write(scripts/**)",
+            "Write(docs/**)",
+            "Edit(*.md)",
+            "Edit(*.yml)",
+            "Edit(*.yaml)",
+            "Edit(*.json)",
+            "Edit(*.toml)",
+            "Edit(.github/**)",
+            "Edit(.gitignore)",
+            "Edit(scripts/**)",
+            "Edit(docs/**)",
+            "Grep(*)",
+            "Glob(*)"
+        ],
+        "deny": [
+            "Bash(rm -rf /:*)",
+            "Bash(sudo:*)",
+            "Bash(su:*)",
+            "Bash(shutdown:*)",
+            "Bash(reboot:*)",
+            "Bash(git push --force:*)",
+            "Bash(git push -f:*)",
+            "Bash(dd:*)",
+            "Bash(mkfs:*)",
+            "Bash(rm:*)",
+            "Bash(docker:*)",
+            "Bash(pip:*)",
+            "Bash(npm:*)",
+            "Bash(python:*)",
+            "Bash(python3:*)",
+            "Bash(node:*)",
+            "Read(.env*)",
+            "Read(**/secrets/**)",
+            "Read(~/.ssh/**)",
+            "Read(~/.aws/**)",
+            "Read(~/.config/gcloud/**)",
+            "Read(**/*credentials*)",
+            "Read(**/*token*)",
+            "Write(.env*)",
+            "Edit(.env*)",
+            "Write(~/.ssh/**)",
+            "Write(~/.aws/**)"
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- Deploys corrected `.claude/settings.json` with **INFRA** domain profile
- Fixes `enabledPlugins` format: now uses `{"name@marketplace": true}` object (was array)
- Adds permissions allow/deny list, hooks (branch-protection, test-gate), sandbox config

## What changed
| Section | Before | After |
|---------|--------|-------|
| `enabledPlugins` | Array (ignored by Claude Code) | Object with `name@marketplace` keys |
| `permissions.allow` | Missing | Domain-specific tool allowlist |
| `permissions.deny` | Missing | Destructive commands + secrets blocked |
| `hooks` | Missing | branch-protection + test-gate |
| `sandbox` | Missing | Enabled with auto-allow |

## Domain profile: **INFRA**
- 22 plugins enabled
- 39 permission allows
- 27 permission denies

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>